### PR TITLE
Automatically create a Part for new Components

### DIFF
--- a/src/capellambse/metamodel/cs.py
+++ b/src/capellambse/metamodel/cs.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import typing as t
 import warnings
 
+from lxml import etree
+
 import capellambse.model as m
 
 from . import capellacore, fa, information, modellingcore
@@ -191,7 +193,8 @@ class Component(
     physical_ports = m.Filter["PhysicalPort"](
         "owned_features", (NS, "PhysicalPort")
     )
-    parts = m.Backref["Part"]((NS, "Part"), "type")
+    owned_parts = m.Filter["Part"]("owned_features", (NS, "Part"))
+    representing_parts = m.Backref["Part"]((NS, "Part"), "type")
     physical_paths = m.Containment["PhysicalPath"](
         "ownedPhysicalPath", (NS, "PhysicalPath")
     )
@@ -212,6 +215,23 @@ class Component(
     if not t.TYPE_CHECKING:
         owner = m.DeprecatedAccessor("parent")
         exchanges = m.DeprecatedAccessor("component_exchanges")
+        parts = m.DeprecatedAccessor("representing_parts")
+
+    def __init__(
+        self,
+        model: m.MelodyModel,
+        parent: etree._Element,
+        /,
+        create_part: bool = True,
+        **kw: t.Any,
+    ) -> None:
+        super().__init__(model, parent, **kw)
+
+        if create_part:
+            if isinstance(self.parent, Component | ComponentPkg):
+                self.parent.owned_parts.create(name=self.name, type=self)
+            else:
+                self.owned_parts.create(name=self.name, type=self)
 
 
 class DeployableElement(capellacore.NamedElement, abstract=True):
@@ -597,6 +617,7 @@ class ComponentPkg(capellacore.Structure, abstract=True):
     """A package containing parts."""
 
     parts = m.Containment["Part"]("ownedParts", (NS, "Part"))
+    owned_parts = m.Alias["m.ElementList[Part]"]("parts")
     exchanges = m.Containment["fa.ComponentExchange"](
         "ownedComponentExchanges", (ns.FA, "ComponentExchange")
     )

--- a/src/capellambse/metamodel/pa/__init__.py
+++ b/src/capellambse/metamodel/pa/__init__.py
@@ -221,7 +221,7 @@ class PhysicalComponent(
         self,
     ) -> m.ElementList[PhysicalComponent]:
         return (
-            self.parts.map("deployment_links")
+            self.representing_parts.map("deployment_links")
             .map("deployed_element")
             .map("type")
         )

--- a/tests/test_metamodel_cs.py
+++ b/tests/test_metamodel_cs.py
@@ -4,6 +4,8 @@
 from capellambse import MelodyModel
 from capellambse.metamodel import cs
 
+HOGWARTS_UUID = "0d2edb8f-fa34-4e73-89ec-fb9a63001440"
+
 
 def test_PhysicalPath_has_ordered_list_of_involved_items(model: MelodyModel):
     expected = [
@@ -80,3 +82,14 @@ def test_PhysicalLink_setting_source_and_target(model: MelodyModel):
     assert source_pp == link.source
     assert target_pp == link.ends[1]
     assert target_pp == link.target
+
+
+def test_creating_a_component_also_creates_a_part(model: MelodyModel):
+    name = "Component and part creation test"
+    obj = model.by_uuid(HOGWARTS_UUID)
+    assert name not in obj.owned_parts.by_name
+
+    comp = obj.components.create(name=name)
+
+    part = obj.owned_parts.by_type(comp, single=True)
+    assert part.name == comp.name


### PR DESCRIPTION
This PR implements the `cs.Part` creation of at least one part when creating a new Component. The name of the Part is now correctly inferred from its type.