### PR TITLE
fix: Deprecate `Diagram.as_<fmt>` in favor of `Diagram.render("<fmt>")`

### DIFF
--- a/docs/source/examples/01 Introduction.ipynb
+++ b/docs/source/examples/01 Introduction.ipynb
@@ -641,7 +641,7 @@
    "id": "f678a3ee-ac7e-4ce4-a8e2-0d41c612800e",
    "metadata": {},
    "source": [
-    "We use SVG diagrams a lot since they look great in documentation, are zoomable and really light-weight. To make integrating them into a pipeline easier, we also support some derived formats, which you can access using `.as_<format>` style attributes. With some additional dependencies set up (see the README), capellambse can also automatically convert these images to PNG format."
+    "We use SVG diagrams a lot since they look great in documentation, are zoomable and really light-weight. To make integrating them into a pipeline easier, we also support some derived formats, which you can access using the `.render(format)` method. With some additional dependencies set up (see the README), capellambse can also automatically convert these images to PNG format."
    ]
   },
   {
@@ -663,10 +663,10 @@
    ],
    "source": [
     "# fmt: off\n",
-    "print(repr(  diagram.as_svg          )[:100], \"...\")  # The raw SVG format as simple python `str`\n",
-    "print(repr(  diagram.as_datauri_svg  )[:100], \"...\")  # An SVG, base64-encoded as `data:` URI\n",
-    "print(repr(  diagram.as_html_img     )[:100], \"...\")  # An HTML `<img>` tag, using the above `data:` URI as `src`\n",
-    "print(repr(  diagram.as_png          )[:100], \"...\")  # A raw PNG byte stream, which can be written to a `.png` file"
+    "print(repr(  diagram.render(\"svg\")          )[:100], \"...\")  # The raw SVG format as simple python `str`\n",
+    "print(repr(  diagram.render(\"datauri_svg\")  )[:100], \"...\")  # An SVG, base64-encoded as `data:` URI\n",
+    "print(repr(  diagram.render(\"html_img\")     )[:100], \"...\")  # An HTML `<img>` tag, using the above `data:` URI as `src`\n",
+    "print(repr(  diagram.render(\"png\")          )[:100], \"...\")  # A raw PNG byte stream, which can be written to a `.png` file"
    ]
   },
   {

--- a/docs/source/examples/04 Intro to Jinja templating.ipynb
+++ b/docs/source/examples/04 Intro to Jinja templating.ipynb
@@ -515,7 +515,7 @@
     "{{ component.description }}\n",
     "<table>\n",
     "    <caption>Figure {{ fig_id }}: {{ fig_caption | e }}</caption>\n",
-    "    <tr><td>{{ figure.as_svg | safe }}</td></tr>\n",
+    "    <tr><td>{{ figure.render(\"svg\") | safe }}</td></tr>\n",
     "</table>\n",
     "\"\"\"\n",
     "diagram = model.diagrams.by_name(\"[LAB] Wizard Education\")\n",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,7 +51,7 @@ using Polarsys' Capella_ with Python. Common usage for this API:
 * parsing .aird files
 * easy access to model elements and objects
 * property-value access and manipulation
-* diagram access and export as SVG
+* diagram access and rendering to SVG or PNG format
 
 Additionally and as a core idea it provides an interface for the underlying
 database of the Capella model.
@@ -74,6 +74,7 @@ If you want a quickstart at how to use this package, head right into the
    start/intro-to-api
    start/declarative
    start/migrating-0.6
+   start/migrating-0.8
 
 .. toctree::
    :caption: Tutorials

--- a/docs/source/start/intro-to-api.rst
+++ b/docs/source/start/intro-to-api.rst
@@ -61,3 +61,16 @@ Extension packages
   Requirements within Capella model.
 * :mod:`capellambse.extensions.pvmt` - provides means for working with object
   attributes created with PVMT package.
+
+Working with diagrams
+======================
+
+Diagram objects provide access to the visual representations in your Capella
+model. To render diagrams to different formats, use the ``render()`` method:
+
+.. code-block:: python
+
+   diagram = model.diagrams.by_name("[SDFB] System Context")
+
+   svg_data = diagram.render("svg")
+   png_data = diagram.render("png")

--- a/docs/source/start/migrating-0.8.rst
+++ b/docs/source/start/migrating-0.8.rst
@@ -1,0 +1,44 @@
+..
+   SPDX-FileCopyrightText: Copyright DB InfraGO AG
+   SPDX-License-Identifier: Apache-2.0
+
+Migrating from |project| v0.7.x to v0.8.x
+=========================================
+
+This page lists the most important differences that users should be aware of
+when upgrading to v0.8.x from earlier versions of |project|.
+
+Deprecated diagram rendering properties
+---------------------------------------
+
+- The ``as_<format>`` properties (e.g., ``as_svg``, ``as_png``) on ``Diagram``
+  objects have been **deprecated** in favor of the more flexible ``render()``
+  method.
+
+  **Before (deprecated):**
+
+  .. code-block:: python
+
+     diagram = model.diagrams.by_name("My Diagram")
+     svg_data = diagram.as_svg
+     png_data = diagram.as_png
+
+  **After (recommended):**
+
+  .. code-block:: python
+
+     diagram = model.diagrams.by_name("My Diagram")
+     svg_data = diagram.render("svg")
+     png_data = diagram.render("png")
+
+  Note that this does not change any of the semantics behind diagram rendering.
+  Specifically, `render()` calls are cached across consecutive calls with the
+  same render parameters. The following code still renders the diagram only
+  once and converts this rendered diagram into the different formats:
+
+  .. code-block:: python
+
+     diagram = model.diagrams.by_name("My Diagram")
+     raw_svg = diagram.render("svg")
+     datauri = diagram.render("datauri_svg")
+     png = diagram.render("png")

--- a/src/capellambse/model/_model.py
+++ b/src/capellambse/model/_model.py
@@ -253,7 +253,7 @@ class MelodyModel:
             format. Example:
 
             - Diagram ID: ``_7FWu4KrxEeqOgqWuHJrXFA``
-            - Render call: ``diag_obj.as_svg`` or ``diag_obj.render("svg")``
+            - Render call: ``diag_obj.render("svg")``
             - Cache file name: ``_7FWu4KrxEeqOgqWuHJrXFA.svg``
 
             *This argument is **not** passed to the file handler.*

--- a/src/capellambse/model/diagram.py
+++ b/src/capellambse/model/diagram.py
@@ -37,6 +37,7 @@ import os
 import traceback
 import typing as t
 import uuid
+import warnings
 
 import markupsafe
 from lxml import etree
@@ -248,15 +249,19 @@ class AbstractDiagram(metaclass=abc.ABCMeta):
     def __init__(self, model: capellambse.MelodyModel) -> None:
         self._model = model
 
-    def __dir__(self) -> list[str]:
-        return dir(type(self)) + [
-            f"as_{ep.name}"
-            for ep in imm.entry_points(group="capellambse.diagram.formats")
-        ]
-
     def __getattr__(self, attr: str) -> t.Any:
         if attr.startswith("as_"):
             fmt = attr[len("as_") :]
+            warnings.warn(
+                (
+                    "The `diagram.as_<format>` properties are deprecated,"
+                    ' use `diagram.render("<format>")` instead'
+                    f' (i.e. `diagram.render("{fmt}")`)'
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
             try:
                 return self.render(fmt)
             except UnknownOutputFormat:

--- a/src/capellambse/sphinx.py
+++ b/src/capellambse/sphinx.py
@@ -146,7 +146,7 @@ class DiagramDirective(sphinx.util.docutils.SphinxDirective):
                 f"Cannot find diagram {name!r} in the configured model"
             ) from error
 
-        uri = diagram.as_datauri_svg
+        uri = diagram.render("datauri_svg")
         return [
             nodes.image(rawsource=self.block_text, uri=uri, **self.options)
         ]


### PR DESCRIPTION
The `as_<format>` properties (e.g., `as_svg`, `as_png`) are now deprecated in favor of the `render()` method. Users should use `diagram.render("format")` instead of `diagram.as_format`.

The `as_<format>` properties have several limitations: they don't support additional render parameters (unlike `render("format", **params)`), and they obscure the computational cost of diagram rendering by making it look like a simple attribute lookup. This also complicates introspection tools, which must special-case diagram objects to avoid accidentally triggering the expensive rendering operations.