### PR TITLE
Support `promise_id` in top-level decl instructions

### DIFF
--- a/src/capellambse/decl.py
+++ b/src/capellambse/decl.py
@@ -345,6 +345,22 @@ def _is_pep440(version: str) -> bool:
     return pep440_ptrn.fullmatch(version) is not None
 
 
+def _operate_promise_id(
+    promises: dict[Promise, capellambse.ModelObject],
+    parent: capellambse.ModelObject,
+    pid: t.Any,
+) -> cabc.Generator[_OperatorResult, t.Any, None]:
+    del promises
+    if isinstance(pid, str):
+        promise = Promise(pid)
+    elif isinstance(pid, Promise):
+        promise = pid
+    else:
+        raise TypeError("promise_id must be a string or !promise")
+
+    yield (promise, parent)
+
+
 def _operate_create(
     promises: dict[Promise, capellambse.ModelObject],
     parent: capellambse.ModelObject,
@@ -599,6 +615,7 @@ class _NoObjectFoundError(ValueError):
 
 _OPERATIONS = collections.OrderedDict(
     (
+        ("promise_id", _operate_promise_id),
         ("create", _operate_create),
         ("extend", _operate_extend),
         ("set", _operate_set),


### PR DESCRIPTION
Analogous to when `parent:` gained support for `!promise`, this commit introduces the ability to specify a `promise_id:` for a top-level instruction.

This enables two new interesting use cases:

1. It allows resolving promises with objects that are lookup up from the model directly, e.g. by their ID:

   ```yaml
   - parent: !uuid 01234567-89ab-cdef-0123-456789abcdef
     extend:
       activities: [!promise my-object]
   - parent: !uuid fedcba98-7654-3210-fedc-ba9876543210
     promise_id: my-object
   ```

2. It allows renaming promises without relying on e.g. `sync` to find the object it just created:

   ```yaml
   - parent: !promise name-1
     promise_id: name-2
   ```