### PR TITLE
Update pyo3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-pyo3 = { version = "0.28.0", features = ["abi3-py310", "extension-module"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py310", "extension-module"] }
 
 [lib]
 name = "_compiled"


### PR DESCRIPTION
Update rust build dependency pyo3 to address possible security issues.

Ref: GHSA-36hh-v3qg-5jq4
Ref: GHSA-chgr-c6px-7xpp